### PR TITLE
Special meeting get_posts fix

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -407,7 +407,7 @@ function get_next_meeting( $committee='None', $args=array() ) {
 				),
 				array(
 					'key'      => 'ucf_meeting_special_meeting',
-					'value'    => 1,
+					'value'    => '1',
 					'compare'  => '!='
 				)
 			)
@@ -434,7 +434,7 @@ function get_next_special_meeting( $committee='None', $args=array() ) {
 		'meta_key'       => 'ucf_meeting_date',
 		'meta_type'      => 'DATETIME',
 		'orderby'        => 'meta_value',
-		'order'          => 'DESC',
+		'order'          => 'ASC',
 		'meta_query' => array(
 			array(
 				'key'     => 'ucf_meeting_date',
@@ -450,7 +450,7 @@ function get_next_special_meeting( $committee='None', $args=array() ) {
 			array(
 				'key'     => 'ucf_meeting_special_meeting',
 				'value'   => '1',
-				'compare' => '=='
+				'compare' => '='
 			)
 		)
 	);

--- a/functions.php
+++ b/functions.php
@@ -398,6 +398,18 @@ function get_next_meeting( $committee='None', $args=array() ) {
 				'key'     => 'ucf_meeting_committee',
 				'value'   => $committee['term_id'],
 				'compare' => '='
+			),
+			array(
+				'relation' => 'OR',
+				array(
+					'key'      => 'ucf_meeting_special_meeting',
+					'compare'  => 'NOT EXISTS'
+				),
+				array(
+					'key'      => 'ucf_meeting_special_meeting',
+					'value'    => 1,
+					'compare'  => '!='
+				)
 			)
 		)
 	);


### PR DESCRIPTION
The args array for get_posts was pulling in all meetings in some cases, and meetings in the reverse order in others. This fixes those issues.