### PR TITLE
Updated meeting query to display next meeting all day long

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -378,13 +378,13 @@ function get_latest_meeting_minutes( $committee='None', $args=array() ) {
 }
 
 function get_next_meeting( $committee='None', $args=array() ) {
-	$today = date('Y-m-d H:i:s');
+	$today = date('Y-m-d');
 	$committee = term_exists( $committee, 'people_group' );
 
 	$args = array(
 		'posts_per_page' => 1,
 		'meta_key'       => 'ucf_meeting_date',
-		'meta_type'      => 'DATETIME',
+		'meta_type'      => 'DATE',
 		'orderby'        => 'meta_value',
 		'order'          => 'ASC',
 		'meta_query'     => array(
@@ -392,7 +392,7 @@ function get_next_meeting( $committee='None', $args=array() ) {
 				'key'     => 'ucf_meeting_date',
 				'value'   => $today,
 				'compare' => '>=',
-				'type'    => 'DATETIME'
+				'type'    => 'DATE'
 			),
 			array(
 				'key'     => 'ucf_meeting_committee',
@@ -426,13 +426,13 @@ function get_next_meeting( $committee='None', $args=array() ) {
 }
 
 function get_next_special_meeting( $committee='None', $args=array() ) {
-	$today = date('Y-m-d H:i:s');
+	$today = date('Y-m-d');
 	$committee = term_exists( $committee, 'people_group' );
 
 	$args = array(
 		'posts_per_page' => 1,
 		'meta_key'       => 'ucf_meeting_date',
-		'meta_type'      => 'DATETIME',
+		'meta_type'      => 'DATE',
 		'orderby'        => 'meta_value',
 		'order'          => 'ASC',
 		'meta_query' => array(
@@ -440,7 +440,7 @@ function get_next_special_meeting( $committee='None', $args=array() ) {
 				'key'     => 'ucf_meeting_date',
 				'value'   => $today,
 				'compare' => '>=',
-				'type'    => 'DATETIME'
+				'type'    => 'DATE'
 			),
 			array(
 				'key'     => 'ucf_meeting_committee',


### PR DESCRIPTION
Enhancement:
* Update meeting query to show an upcoming meeting that occurs on the current day to display throughout the entire day, even after it's start and end times have passed.