### PR TITLE
Handle no meetings. Update logic to show meetings for most recent year.

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -265,8 +265,17 @@ function display_meetings( $meetings ) {
 
 function display_meetings_by_year( $years ) {
 	ob_start();
+
+	if ( ! $years ) :
+?>
+	<p>No meetings to display.</p>
+<?php
+	return ob_get_clean();
+
+	endif;
+
 	reset( $years );
-	$first_year = (int)date( "Y" );
+	$first_year = ( is_array( $years ) ) ? (int)key( $years ) : null;
 ?>
 	<div class="row">
 		<div class="col-md-8">
@@ -519,7 +528,7 @@ function display_committee_members( $people_group ) {
 	if ( $vice_chair ) {
 		$exclude[] = $vice_chair->ID;
 	}
-	
+
 	if ( $ex_officio ) {
 		$exclude[] = $ex_officio->ID;
 	}


### PR DESCRIPTION
Bug Fixes:
* Update meetings dropdown function to display fallback message when no meeting years are defined.
* Update meetings dropdown to show the first available year by default, not the current year.